### PR TITLE
add Z subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,15 +145,21 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytemuck"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
 
 [[package]]
 name = "byteorder"
@@ -154,9 +169,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
 
 [[package]]
 name = "cexpr"
@@ -245,9 +260,9 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -291,9 +306,9 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -301,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
@@ -315,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote 1.0.36",
@@ -453,6 +468,7 @@ dependencies = [
  "clap",
  "freesasa-rs",
  "kd-tree",
+ "nalgebra",
  "pdbtbx",
  "rand",
  "serde",
@@ -631,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
@@ -649,9 +665,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
  "windows-targets",
@@ -690,15 +706,25 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minimal-lexical"
@@ -716,6 +742,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c4b5f057b303842cf3262c27e465f4c303572e7f6b0648f60e16248ac3397f4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2 1.0.85",
+ "quote 1.0.36",
+ "syn",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,10 +779,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -865,6 +957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -957,6 +1055,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1034,6 +1141,19 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simba"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
 
 [[package]]
 name = "smallvec"
@@ -1210,10 +1330,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-util"
-version = "0.1.8"
+name = "wide"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -467,6 +467,7 @@ version = "0.4.0"
 dependencies = [
  "clap",
  "freesasa-rs",
+ "itertools 0.13.0",
  "kd-tree",
  "nalgebra",
  "pdbtbx",
@@ -614,6 +615,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ rand = "0.8.4"
 kd-tree = "0.6.0"
 clap = { version = "4.5", features = ["derive"] }
 nalgebra = "0.33.0"
+itertools = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ pdbtbx = "0.11.0"
 rand = "0.8.4"
 kd-tree = "0.6.0"
 clap = { version = "4.5", features = ["derive"] }
+nalgebra = "0.33.0"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,4 +9,5 @@
   - [`ti`](./ti.md)
   - [`restraint`](./restraint.md)
   - [`interface`](./interface.md)
+  - [`z`](./z.md)
 - [Development](./development.md)

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -9,3 +9,5 @@
 - [`restraint`: Generate _unambiguous restraints_ to keep molecules together during docking](./restraint.md)
 
 - [`interface`: List residues in the interface](./interface.md)
+
+- [`z`: Generate restraints to keep the molecule aligned to the Z-axis](./z.md)

--- a/docs/src/z.md
+++ b/docs/src/z.md
@@ -1,0 +1,21 @@
+# Generate `z` restraints to keep the molecule aligned to the Z-axis
+
+This subcommand generates restraints to keep the molecule aligned to the Z-axis. This is useful when you want to keep the molecule in a specific orientation during docking.
+
+As input you need to pass at least one selection of residues, this will be used to define a plane perpendicular to the Z-axis. The restraints will be generated to keep the molecule aligned to this plane.
+
+## Usage
+
+To run the `z` subcommand, you need to provide the path to the PDB file, the selection of residues, the output file which will contain the shape beads, the number of beads to generate, and the distance between the beads. For example:
+
+```bash
+./haddock-restraints z \
+  --residues 19,83,145,119,167 \
+  path/to/the/input.pdb \
+  path/to/the/output/shape.pdb \
+  20 \ # spacing between the beads in angstrom - 20A
+  6 \  # grid size in dimension - 6x6
+  > z_restraints.tbl
+```
+
+Further, follow the HADDOCK documentation **\<pending\>** to use the generated restraints in the docking protocol.

--- a/src/air.rs
+++ b/src/air.rs
@@ -1,5 +1,3 @@
-use core::panic;
-
 use crate::interactor;
 
 pub struct Air(Vec<interactor::Interactor>);
@@ -40,7 +38,6 @@ impl Air {
             // let header = append_header(i);
             // tbl.push_str(&header);
 
-            // TODO: Refactor this logic to also collect wildcards
             let target_res = interactor::collect_residues(partners);
             let block = interactor.create_block(target_res);
             tbl.push_str(&block);

--- a/src/air.rs
+++ b/src/air.rs
@@ -1,3 +1,5 @@
+use core::panic;
+
 use crate::interactor;
 
 pub struct Air(Vec<interactor::Interactor>);
@@ -38,6 +40,7 @@ impl Air {
             // let header = append_header(i);
             // tbl.push_str(&header);
 
+            // TODO: Refactor this logic to also collect wildcards
             let target_res = interactor::collect_resnums(partners);
             let block = interactor.create_block(target_res);
             tbl.push_str(&block);

--- a/src/air.rs
+++ b/src/air.rs
@@ -41,7 +41,7 @@ impl Air {
             // tbl.push_str(&header);
 
             // TODO: Refactor this logic to also collect wildcards
-            let target_res = interactor::collect_resnums(partners);
+            let target_res = interactor::collect_residues(partners);
             let block = interactor.create_block(target_res);
             tbl.push_str(&block);
         }

--- a/src/interactor.rs
+++ b/src/interactor.rs
@@ -53,6 +53,9 @@ pub struct Interactor {
 
     /// Optional cutoff value for buried residue filtering.
     filter_buried_cutoff: Option<f64>,
+
+    /// Optional wildcard value for the interactor.
+    wildcard: Option<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -304,13 +307,17 @@ impl Interactor {
         &self.passive
     }
 
-    pub fn wildcard(&self) -> &str {
-        match &self.wildcard {
-            Some(wildcard) => wildcard,
-            None => "",
-        }
-    }
-
+    /// Returns the wildcard string associated with this Interactor.
+    ///
+    /// # Returns
+    ///
+    /// - If a wildcard is set, returns a string slice (`&str`) containing the wildcard value.
+    /// - If no wildcard is set, returns an empty string slice.
+    ///
+    /// # Notes
+    ///
+    /// - This method provides read-only access to the wildcard value.
+    /// - The wildcard is typically used to represent any residue or atom in certain contexts.
     pub fn wildcard(&self) -> &str {
         match &self.wildcard {
             Some(wildcard) => wildcard,
@@ -375,10 +382,20 @@ impl Interactor {
         self.passive = passive.into_iter().collect();
     }
 
-    pub fn set_wildcard(&mut self, wildcard: &str) {
-        self.wildcard = Some(wildcard.to_string());
-    }
-
+    /// Sets the wildcard string for this Interactor.
+    ///
+    /// This method allows you to set or update the wildcard value associated with the Interactor.
+    ///
+    /// # Arguments
+    ///
+    /// * `wildcard` - A string slice (`&str`) that specifies the new wildcard value.
+    ///
+    /// # Notes
+    ///
+    /// - This method will overwrite any previously set wildcard value.
+    /// - The wildcard is stored as an owned `String`, so the input `&str` is cloned.
+    /// - An empty string is a valid wildcard value, though its interpretation may depend on the context.
+    /// - The wildcard is typically used to represent any residue or atom in certain contexts.
     pub fn set_wildcard(&mut self, wildcard: &str) {
         self.wildcard = Some(wildcard.to_string());
     }

--- a/src/interactor.rs
+++ b/src/interactor.rs
@@ -376,8 +376,6 @@ pub fn format_atom_string(atoms: &Option<Vec<String>>) -> String {
     }
 }
 
-// pub fn format_oneline_assign_string()
-
 #[cfg(test)]
 mod tests {
 

--- a/src/interactor.rs
+++ b/src/interactor.rs
@@ -400,8 +400,6 @@ mod tests {
             },
         ]);
 
-        // let observed = interactor.create_block(vec![("B", &2, Some("")), ("B", &3, Some(""))]);
-
         let block = "assign ( resid 1 and segid A )\n       (\n        ( resid 2 and segid B )\n     or\n        ( resid 3 and segid B )\n       ) 2.0 2.0 0.0\n\n";
 
         assert_eq!(observed, block);

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,21 @@ enum Commands {
         #[arg(help = "Cutoff distance for interface residues")]
         cutoff: f64,
     },
+
+    Z {
+        #[arg(help = "Input file")]
+        input: String,
+        #[arg(help = "List of comma separated residue indexes")]
+        residues: String,
+        #[arg(help = "Output file")]
+        output: String,
+        #[arg(help = "Spacing between two beads")]
+        spacing: f64,
+        #[arg(help = "Size in x dimension")]
+        x_size: f64,
+        #[arg(help = "Size in y dimension")]
+        y_size: f64,
+    },
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -60,6 +75,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::Interface { input, cutoff } => {
             let _ = list_interface(input, cutoff);
+        }
+        Commands::Z {
+            input,
+            residues,
+            output,
+            spacing,
+            x_size,
+            y_size,
+        } => {
+            let _ = generate_z(input, residues, output, spacing, x_size, y_size);
         }
     }
 
@@ -202,4 +227,15 @@ fn list_interface(input_file: &str, cutoff: &f64) -> Result<(), Box<dyn Error>> 
     }
 
     Ok(())
+}
+
+fn generate_z(
+    input_file: &str,
+    residues: &str,
+    output_file: &str,
+    spacing: &f64,
+    x_size: &f64,
+    y_size: &f64,
+) -> Result<(), Box<dyn Error>> {
+    todo!("Generate Z matrix from input file");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,13 +350,13 @@ fn generate_z_restraints(
                 interactor_i.set_chain("A");
                 interactor_i.set_active(vec![*resnum as i16]);
                 interactor_i.set_active_atoms(vec!["CA".to_string()]);
+                interactor_i.set_passive_atoms(vec!["SHA".to_string()]);
                 interactor_i.set_lower_margin(0.0);
                 interactor_i.set_upper_margin(0.0);
                 interactor_i.set_target_distance(2.0);
 
                 interactor_j.set_chain("S");
-                interactor_j.set_active_atoms(vec!["SHA".to_string()]);
-                interactor_j.set_wildcard(format!("attr z gt {:?}", z).as_str());
+                interactor_j.set_wildcard(format!("attr z gt {:.2}", z).as_str());
 
                 interactors.push(interactor_i);
                 interactors.push(interactor_j);

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,11 +242,11 @@ fn list_interface(input_file: &str, cutoff: &f64) -> Result<(), Box<dyn Error>> 
 
 fn generate_z_restraints(
     input_file: &str,
-    residues: &Vec<Vec<isize>>,
-    output_file: &str,
-    spacing: &f64,
-    x_size: &f64,
-    y_size: &f64,
+    _residues: &[Vec<isize>],
+    _output_file: &str,
+    _spacing: &f64,
+    _x_size: &f64,
+    _y_size: &f64,
 ) -> Result<(), Box<dyn Error>> {
     let pdb = match pdbtbx::open_pdb(input_file, pdbtbx::StrictnessLevel::Loose) {
         Ok((pdb, _warnings)) => pdb,
@@ -258,7 +258,6 @@ fn generate_z_restraints(
     // DEVELOPMENT ----------------------------------------------------------------------------
     let sele1: Vec<isize> = vec![19, 83, 145, 167];
     let sele2: Vec<isize> = vec![98, 101, 126, 129];
-    // ----------------------------------------------------------------------------------------
 
     let target_residues1 = structure::get_residues(&pdb, sele1);
     let target_residues2 = structure::get_residues(&pdb, sele2);
@@ -276,28 +275,28 @@ fn generate_z_restraints(
             atoms2.push(atom.clone());
         }
     }
+    // ----------------------------------------------------------------------------------------
 
-    let z_axis = structure::calculate_z_axis(&atoms1, &atoms2);
+    let _z_axis = structure::calculate_z_axis(&atoms1, &atoms2);
     let center1 = structure::calculate_geometric_center(&atoms1);
     let center2 = structure::calculate_geometric_center(&atoms2);
 
     // Project endpoints onto global Z-axis and center at origin
     let min_z = center1.z.min(center2.z);
     let max_z = center1.z.max(center2.z);
-    let mid_z = (min_z + max_z) / 2.0;
+    let _mid_z = (min_z + max_z) / 2.0;
     let half_length = (max_z - min_z) / 2.0;
 
     // Project endpoints onto global Z-axis
     let start_z = center1.z.min(center2.z);
     let end_z = center1.z.max(center2.z);
-    let start = nalgebra::Vector3::new(0.0, 0.0, start_z);
-    let end = nalgebra::Vector3::new(0.0, 0.0, end_z);
+    let _start = nalgebra::Vector3::new(0.0, 0.0, start_z);
+    let _end = nalgebra::Vector3::new(0.0, 0.0, end_z);
 
     // Generate beads along the global Z-axis
     let num_axis_beads = 10; // Number of beads along the axis
-    let axis_beads = structure::generate_axis_beads(-half_length, half_length, num_axis_beads);
+    let _axis_beads = structure::generate_axis_beads(-half_length, half_length, num_axis_beads);
 
-    // Generate grids at both ends, perpendicular to global Z-axis
     // Generate grids at both ends, perpendicular to global Z-axis
     let grid_size = 5; // 5x5 grid
     let grid_spacing = 2.0; // 2 Angstroms between grid points

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod structure;
 use air::Air;
 use core::panic;
 use interactor::Interactor;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::Path;
@@ -266,6 +267,8 @@ fn generate_z_restraints(
     let atoms1: Vec<pdbtbx::Atom>;
     let atoms2: Vec<pdbtbx::Atom>;
 
+    let mut restraints: HashMap<isize, Vec<structure::Bead>> = HashMap::new();
+
     if selections.len() >= 2 {
         (atoms1, atoms2) = structure::find_furthest_selections(selections, &pdb);
     } else {
@@ -296,8 +299,8 @@ fn generate_z_restraints(
     let half_length = (max_z - min_z) / 2.0;
 
     // Project endpoints onto global Z-axis
-    let start_z = center1.z.min(center2.z);
-    let end_z = center1.z.max(center2.z);
+    // let start_z = center1.z.min(center2.z);
+    // let end_z = center1.z.max(center2.z);
     // let start = nalgebra::Vector3::new(0.0, 0.0, start_z);
     // let end = nalgebra::Vector3::new(0.0, 0.0, end_z);
 
@@ -308,6 +311,9 @@ fn generate_z_restraints(
     // Generate grids at both ends, perpendicular to global Z-axis
     let grid_beads1 = structure::generate_grid_beads(-half_length, *grid_size, *grid_spacing);
     let grid_beads2 = structure::generate_grid_beads(half_length, *grid_size, *grid_spacing);
+
+    restraints.insert(0, grid_beads1.clone());
+    restraints.insert(1, grid_beads2.clone());
 
     // let atoms3 = structure::get_atoms_from_resnumbers(&pdb, &selections[2]);
     // let center_atoms3 = structure::calculate_geometric_center(&atoms3);
@@ -321,6 +327,50 @@ fn generate_z_restraints(
     // all_beads.extend(grid_beads3);
 
     structure::write_beads_pdb(&all_beads, "z_beads.pdb")?;
+
+    let mut interactors: Vec<Interactor> = Vec::new();
+    let mut counter = 0;
+    selections
+        .iter()
+        .enumerate()
+        .for_each(|(index, selection)| {
+            let beads = restraints.get(&(index as isize)).unwrap();
+            // Get the z coordinates of the first bead
+            let z = beads[0].position.z;
+            //
+
+            selection.iter().for_each(|resnum| {
+                let mut interactor_i = Interactor::new(counter);
+                counter += 1;
+                let mut interactor_j = Interactor::new(counter);
+                interactor_j.add_target(counter - 1);
+                interactor_i.add_target(counter);
+                counter += 1;
+
+                interactor_i.set_chain("A");
+                interactor_i.set_active(vec![*resnum as i16]);
+                interactor_i.set_active_atoms(vec!["CA".to_string()]);
+                interactor_i.set_lower_margin(0.0);
+                interactor_i.set_upper_margin(0.0);
+                interactor_i.set_target_distance(2.0);
+
+                interactor_j.set_chain("S");
+                interactor_j.set_active_atoms(vec!["SHA".to_string()]);
+                interactor_j.set_wildcard(format!("attr z gt {:?}", z).as_str());
+
+                interactors.push(interactor_i);
+                interactors.push(interactor_j);
+            });
+        });
+
+    // interactors.iter().for_each(|interactor| {
+    //     println!("Interactor: {:?}", interactor);
+    // });
+
+    let air = Air::new(interactors);
+    let tbl = air.gen_tbl().unwrap();
+
+    println!("{}", tbl);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,17 +263,17 @@ fn generate_z_restraints(
         }
     };
 
-    // DEVELOPMENT, move the pdb to the origin --------------------------------------------------
-    let mut debug_pdb = pdb.clone();
-    structure::move_to_origin(&mut debug_pdb);
-    let output_path = Path::new("input.pdb");
-    let file = File::create(output_path)?;
-    pdbtbx::save_pdb_raw(
-        &debug_pdb,
-        BufWriter::new(file),
-        pdbtbx::StrictnessLevel::Strict,
-    );
-    // -----------------------------------------------------------------------------------------
+    // // DEVELOPMENT, move the pdb to the origin --------------------------------------------------
+    // let mut debug_pdb = pdb.clone();
+    // structure::move_to_origin(&mut debug_pdb);
+    // let output_path = Path::new("input.pdb");
+    // let file = File::create(output_path)?;
+    // pdbtbx::save_pdb_raw(
+    //     &debug_pdb,
+    //     BufWriter::new(file),
+    //     pdbtbx::StrictnessLevel::Strict,
+    // );
+    // // -----------------------------------------------------------------------------------------
 
     let atoms1: Vec<pdbtbx::Atom>;
     let atoms2: Vec<pdbtbx::Atom>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,12 +325,15 @@ fn generate_z_restraints(
 
     let mut interactors: Vec<Interactor> = Vec::new();
     let mut counter = 0;
+    let restraint_distance = ((grid_spacing / 2.0) - 2.0).max(2.0);
     selections
         .iter()
         .enumerate()
         .for_each(|(index, selection)| {
             let beads = restraints.get(&(index)).unwrap();
             let z = beads[0].position.z;
+
+            let comparison_operator = if z >= 0.0 { "ge" } else { "le" };
 
             selection.iter().for_each(|resnum| {
                 let mut interactor_i = Interactor::new(counter);
@@ -344,12 +347,13 @@ fn generate_z_restraints(
                 interactor_i.set_active(vec![*resnum as i16]);
                 interactor_i.set_active_atoms(vec!["CA".to_string()]);
                 interactor_i.set_passive_atoms(vec!["SHA".to_string()]);
-                interactor_i.set_lower_margin(0.0);
+                interactor_i.set_target_distance(restraint_distance);
+                interactor_i.set_lower_margin(restraint_distance);
                 interactor_i.set_upper_margin(0.0);
-                interactor_i.set_target_distance(2.0);
 
                 interactor_j.set_chain("S");
-                interactor_j.set_wildcard(format!("attr z gt {:.2}", z).as_str());
+                interactor_j
+                    .set_wildcard(format!("and attr z {} {:.3}", comparison_operator, z).as_str());
 
                 interactors.push(interactor_i);
                 interactors.push(interactor_j);

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,8 +47,8 @@ enum Commands {
     Z {
         #[arg(help = "Input file")]
         input: String,
-        #[arg(help = "List of comma separated residue indexes")]
-        residues: String,
+        #[arg(long, required = true, help = "Group of residue indexes (can be specified multiple times)", value_parser = parse_residues, number_of_values = 1)]
+        residues: Vec<Vec<isize>>,
         #[arg(help = "Output file")]
         output: String,
         #[arg(help = "Spacing between two beads")]
@@ -58,6 +58,17 @@ enum Commands {
         #[arg(help = "Size in y dimension")]
         y_size: f64,
     },
+}
+
+// Parse a comma-separated list of residues
+fn parse_residues(arg: &str) -> Result<Vec<isize>, String> {
+    arg.split(',')
+        .map(|s| {
+            s.trim()
+                .parse::<isize>()
+                .map_err(|_| format!("Invalid number: {}", s))
+        })
+        .collect()
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -84,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             x_size,
             y_size,
         } => {
-            let _ = generate_z(input, residues, output, spacing, x_size, y_size);
+            let _ = generate_z_restraints(input, residues, output, spacing, x_size, y_size);
         }
     }
 
@@ -229,13 +240,77 @@ fn list_interface(input_file: &str, cutoff: &f64) -> Result<(), Box<dyn Error>> 
     Ok(())
 }
 
-fn generate_z(
+fn generate_z_restraints(
     input_file: &str,
-    residues: &str,
+    residues: &Vec<Vec<isize>>,
     output_file: &str,
     spacing: &f64,
     x_size: &f64,
     y_size: &f64,
 ) -> Result<(), Box<dyn Error>> {
-    todo!("Generate Z matrix from input file");
+    let pdb = match pdbtbx::open_pdb(input_file, pdbtbx::StrictnessLevel::Loose) {
+        Ok((pdb, _warnings)) => pdb,
+        Err(e) => {
+            panic!("Error opening PDB file: {:?}", e);
+        }
+    };
+
+    // DEVELOPMENT ----------------------------------------------------------------------------
+    let sele1: Vec<isize> = vec![19, 83, 145, 167];
+    let sele2: Vec<isize> = vec![98, 101, 126, 129];
+    // ----------------------------------------------------------------------------------------
+
+    let target_residues1 = structure::get_residues(&pdb, sele1);
+    let target_residues2 = structure::get_residues(&pdb, sele2);
+
+    // Transform the Residues into a Vector of pdbtbx::Atom
+    let mut atoms1: Vec<pdbtbx::Atom> = Vec::new();
+    for residue in target_residues1.iter() {
+        for atom in residue.atoms() {
+            atoms1.push(atom.clone());
+        }
+    }
+    let mut atoms2: Vec<pdbtbx::Atom> = Vec::new();
+    for residue in target_residues2.iter() {
+        for atom in residue.atoms() {
+            atoms2.push(atom.clone());
+        }
+    }
+
+    let z_axis = structure::calculate_z_axis(&atoms1, &atoms2);
+    let center1 = structure::calculate_geometric_center(&atoms1);
+    let center2 = structure::calculate_geometric_center(&atoms2);
+
+    // Project endpoints onto global Z-axis and center at origin
+    let min_z = center1.z.min(center2.z);
+    let max_z = center1.z.max(center2.z);
+    let mid_z = (min_z + max_z) / 2.0;
+    let half_length = (max_z - min_z) / 2.0;
+
+    // Project endpoints onto global Z-axis
+    let start_z = center1.z.min(center2.z);
+    let end_z = center1.z.max(center2.z);
+    let start = nalgebra::Vector3::new(0.0, 0.0, start_z);
+    let end = nalgebra::Vector3::new(0.0, 0.0, end_z);
+
+    // Generate beads along the global Z-axis
+    let num_axis_beads = 10; // Number of beads along the axis
+    let axis_beads = structure::generate_axis_beads(-half_length, half_length, num_axis_beads);
+
+    // Generate grids at both ends, perpendicular to global Z-axis
+    // Generate grids at both ends, perpendicular to global Z-axis
+    let grid_size = 5; // 5x5 grid
+    let grid_spacing = 2.0; // 2 Angstroms between grid points
+    let grid_beads1 = structure::generate_grid_beads(-half_length, grid_size, grid_spacing);
+    let grid_beads2 = structure::generate_grid_beads(half_length, grid_size, grid_spacing);
+
+    // Combine all beads
+    // let mut all_beads = axis_beads;
+    let mut all_beads = Vec::new();
+    all_beads.extend(grid_beads1);
+    all_beads.extend(grid_beads2);
+
+    structure::write_beads_pdb(&all_beads, "z_beads.pdb")?;
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,6 @@ use air::Air;
 use core::panic;
 use interactor::Interactor;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::BufWriter;
-use std::path::Path;
 use std::{error::Error, vec};
 
 use clap::{Parser, Subcommand};
@@ -544,7 +541,3 @@ fn generate_z_restraints(
 
     Ok(())
 }
-
-// sele s1, resid 19+83+145+167 and input
-// sele s2, resid 98+101+126+129 and input
-// sele s3, resid 23+62+87+111+116+153+163 and input

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -11,8 +11,9 @@ use rand::SeedableRng;
 use std::fs::File;
 use std::io::Write;
 
+#[derive(Clone)]
 pub struct Bead {
-    position: Vector3<f64>,
+    pub position: Vector3<f64>,
 }
 
 pub fn neighbor_search(

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -543,16 +543,6 @@ pub fn get_atoms_from_resnumbers(pdb: &PDB, selection: &[isize]) -> Vec<Atom> {
         .collect()
 }
 
-pub fn move_to_origin(pdb: &mut PDB) {
-    let center = calculate_geometric_center(&pdb.atoms().cloned().collect::<Vec<_>>());
-    for atom in pdb.atoms_mut() {
-        let x = atom.x() - center.x;
-        let y = atom.y() - center.y;
-        let z = atom.z() - center.z;
-        let _ = atom.set_pos((x, y, z));
-    }
-}
-
 #[cfg(test)]
 mod tests {
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -276,12 +276,22 @@ pub fn write_beads_pdb(beads: &[Bead], filename: &str) -> std::io::Result<()> {
     for (i, bead) in beads.iter().enumerate() {
         writeln!(
             file,
-            "ATOM  {:5}  H   SHA S {:3}    {:8.3}{:8.3}{:8.3}  1.00  0.00           H",
+            "{:<6}{:>5} {:<4}{:1}{:<3} {:1}{:>4}{:1}   {:>8.3}{:>8.3}{:>8.3}{:>6.2}{:>6.2}          {:>2}{:>2}",
+            "ATOM",
             i + 1,
+            "SHA",
+            " ",
+            "SHA",
+            "S",
             i + 1,
+            " ",
             bead.position.x,
             bead.position.y,
-            bead.position.z
+            bead.position.z,
+            1.00,
+            1.00,
+            "H",
+            ""
         )?;
     }
     writeln!(file, "END")?;
@@ -322,6 +332,16 @@ pub fn get_atoms_from_resnumbers(pdb: &PDB, selection: &[isize]) -> Vec<Atom> {
         .flat_map(|res| res.atoms())
         .cloned() // This clones each &Atom into an owned Atom
         .collect()
+}
+
+pub fn move_to_origin(pdb: &mut PDB) {
+    let center = calculate_geometric_center(&pdb.atoms().cloned().collect::<Vec<_>>());
+    for atom in pdb.atoms_mut() {
+        let x = atom.x() - center.x;
+        let y = atom.y() - center.y;
+        let z = atom.z() - center.z;
+        let _ = atom.set_pos((x, y, z));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I understand the idea behind this is to, given some residue selections, 1) define a plane between them, 2) draw a grid of shape beads around the geometric center of the selection that is perpendicular to this plane and 3) orient this plane at the global z-axis

Also considering the way haddock works, I assume the shape beads needs to be centered at the origin because If everything is centered at the origin then the z-coordinates of the shape will be +/-, then we just use CNS's `attr z gt` syntax, right?

![test01](https://github.com/user-attachments/assets/be75fbe1-501c-4457-b738-11ba61eaa276)


Other considerations; 

- The dimensions of the bead grid (5x5, 10x10, etc) is an argument - wouldn't it be better if it was automatically determined based on the radius of gyration? > After discussing with @VGPReys it's best indeed if we keep these as a parameter, since all sorts of dynamic assignment might incur in underestimation
- Should these beads be a grid or circular? > Same here, best to be a grid to avoid undersampling