### PR TITLE
Add `passive_from_active_radius` parameter

### DIFF
--- a/docs/src/configuration_file.md
+++ b/docs/src/configuration_file.md
@@ -45,6 +45,7 @@ A minimal configuration file would look like this:
 
 - `structure`: the PDB file that contains the structure of the interactor
 - `passive_from_active`: if true, the passive residues are defined based on the active residues (_requires structure_)
+- `passive_from_active_cutoff`: radius used to search for passive residues around the active (requires structure)
 - `surface_as_passive`: if true, the passive residues are defined based on the surface accessibility of the residues (_requires structure_)
 - `filter_buried`: if true, the buried residues are filtered out (_requires structure_)
 - `filter_buried_cutoff`: the cutoff to consider a residue as buried, default = 0.7 (_requires structure_)

--- a/examples/restraints.json
+++ b/examples/restraints.json
@@ -7,6 +7,7 @@
     "structure": "2oob.pdb",
     "target": [2],
     "passive_from_active": true,
+    "passive_from_active_radius": 6.5,
     "filter_buried": true
   },
   {

--- a/src/interactor.rs
+++ b/src/interactor.rs
@@ -47,6 +47,9 @@ pub struct Interactor {
     /// Optional flag to determine if passive residues should be derived from active ones.
     passive_from_active: Option<bool>,
 
+    /// Optional radius to define the neighbor search radius
+    passive_from_active_radius: Option<f64>,
+
     /// Optional flag to treat surface residues as passive.
     surface_as_passive: Option<bool>,
 
@@ -85,6 +88,7 @@ impl Interactor {
             target: HashSet::new(),
             structure: None,
             passive_from_active: None,
+            passive_from_active_radius: None,
             surface_as_passive: None,
             filter_buried: None,
             filter_buried_cutoff: None,
@@ -152,7 +156,8 @@ impl Interactor {
                     self.active.iter().map(|x| *x as isize).collect(),
                 );
 
-                let neighbors = structure::neighbor_search(pdb.clone(), residues, 5.0);
+                let search_cutoff = self.passive_from_active_radius.unwrap_or(6.5);
+                let neighbors = structure::neighbor_search(pdb.clone(), residues, search_cutoff);
 
                 // Add these neighbors to the passive set
                 neighbors.iter().for_each(|x| {
@@ -790,6 +795,7 @@ mod tests {
         let mut interactor = Interactor::new(1);
         interactor.set_structure("tests/data/complex.pdb");
         interactor.set_active(vec![1]);
+        interactor.passive_from_active_radius = Some(5.0);
         interactor.set_passive_from_active();
 
         let expected_passive = [16, 15, 18, 3, 19, 61, 56, 17, 2, 62, 63];


### PR DESCRIPTION
This PR adds the `passive_from_active_radius` parameter, allowing users to change the value of the neighbour search algorithm. The motivation of this change is to keep code parity with the built-in functionality in haddock3 https://github.com/haddocking/haddock3/pull/1206